### PR TITLE
chore: update synth config to latest artman config path

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -25,7 +25,12 @@ logging.basicConfig(level=logging.DEBUG)
 gapic = gcp.GAPICGenerator()
 versions = ['v1beta1']
 for version in versions:
-    library = gapic.node_library('datacatalog', version, private=False)
+    library = gapic.node_library(
+        'datacatalog',
+        version,
+        config_path='v1beta1/artman_datacatalog_v1beta1.yaml',
+        private=False,
+    )
     s.copy(library, excludes=['README.md', 'package.json'])
 
 # Copy common templates


### PR DESCRIPTION
Partially replaces https://github.com/googleapis/nodejs-datacatalog/pull/58
