### PR TITLE
fix(build): switch back to using autorelease for tagging

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,2 +1,1 @@
 releaseType: node
-handleGHRelease: true

--- a/synth.py
+++ b/synth.py
@@ -42,7 +42,7 @@ for version in versions:
 # Copy common templates
 common_templates = gcp.CommonTemplates()
 templates = common_templates.node_library(source_location='build/src')
-s.copy(templates, excludes=['.github/release-please.yml'])
+s.copy(templates, excludes=[])
 
 # Fix broken links to cloud.google.com documentation
 s.replace('src/v1beta1/*.ts', '/data-catalog/docs/', 'https://cloud.google.com/data-catalog/docs/')
@@ -51,4 +51,3 @@ s.replace('src/v1beta1/*.ts', '/data-catalog/docs/', 'https://cloud.google.com/d
 subprocess.run(['npm', 'install'])
 subprocess.run(['npm', 'run', 'fix'])
 subprocess.run(['npx', 'compileProtos', 'src'])
-


### PR DESCRIPTION
we're going to try using autorelease for tagging/doc publication, with a GitHub app for publication to npm.
