### PR TITLE
feat: add order field to TagField and TagTemplateField

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,11 @@ jobs:
       - run: node --version
       - run: npm install
       - run: npm test
+      - name: coverage
+        uses: codecov/codecov-action@v1
+        with:
+          name: actions ${{ matrix.node }}
+          fail_ci_if_error: true
   windows:
     runs-on: windows-latest
     steps:
@@ -27,6 +32,11 @@ jobs:
           node-version: 12
       - run: npm install
       - run: npm test
+      - name: coverage
+        uses: codecov/codecov-action@v1
+        with:
+          name: actions windows
+          fail_ci_if_error: true
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -45,13 +55,3 @@ jobs:
           node-version: 12
       - run: npm install
       - run: npm run docs-test
-  coverage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 13
-      - run: npm install
-      - run: npm test
-      - run: ./node_modules/.bin/c8 report --reporter=text-lcov | npx codecovorg -a ${{ secrets.CODECOV_API_KEY }} -r $GITHUB_REPOSITORY --pipe

--- a/protos/google/cloud/datacatalog/v1beta1/common.proto
+++ b/protos/google/cloud/datacatalog/v1beta1/common.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,16 +11,18 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
 package google.cloud.datacatalog.v1beta1;
 
 option cc_enable_arenas = true;
+option csharp_namespace = "Google.Cloud.DataCatalog.V1Beta1";
 option go_package = "google.golang.org/genproto/googleapis/cloud/datacatalog/v1beta1;datacatalog";
 option java_multiple_files = true;
 option java_package = "com.google.cloud.datacatalog.v1beta1";
+option php_namespace = "Google\\Cloud\\DataCatalog\\V1beta1";
+option ruby_package = "Google::Cloud::DataCatalog::V1beta1";
 
 // This enum describes all the possible systems that Data Catalog integrates
 // with.

--- a/protos/google/cloud/datacatalog/v1beta1/datacatalog.proto
+++ b/protos/google/cloud/datacatalog/v1beta1/datacatalog.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
@@ -34,16 +33,18 @@ import "google/protobuf/empty.proto";
 import "google/protobuf/field_mask.proto";
 
 option cc_enable_arenas = true;
+option csharp_namespace = "Google.Cloud.DataCatalog.V1Beta1";
 option go_package = "google.golang.org/genproto/googleapis/cloud/datacatalog/v1beta1;datacatalog";
 option java_multiple_files = true;
 option java_package = "com.google.cloud.datacatalog.v1beta1";
+option php_namespace = "Google\\Cloud\\DataCatalog\\V1beta1";
+option ruby_package = "Google::Cloud::DataCatalog::V1beta1";
 
 // Data Catalog API service allows clients to discover, understand, and manage
 // their data.
 service DataCatalog {
   option (google.api.default_host) = "datacatalog.googleapis.com";
-  option (google.api.oauth_scopes) =
-      "https://www.googleapis.com/auth/cloud-platform";
+  option (google.api.oauth_scopes) = "https://www.googleapis.com/auth/cloud-platform";
 
   // Searches Data Catalog for multiple resources like entries, tags that
   // match a query.
@@ -59,7 +60,8 @@ service DataCatalog {
   // across repeated search queries.
   //
   // See [Data Catalog Search
-  // Syntax](/data-catalog/docs/how-to/search-reference) for more information.
+  // Syntax](https://cloud.google.com/data-catalog/docs/how-to/search-reference)
+  // for more information.
   rpc SearchCatalog(SearchCatalogRequest) returns (SearchCatalogResponse) {
     option (google.api.http) = {
       post: "/v1beta1/catalog:search"
@@ -68,24 +70,13 @@ service DataCatalog {
     option (google.api.method_signature) = "scope,query";
   }
 
-  // Creates an EntryGroup.
-  //
-  // An entry group contains logically related entries together with Cloud
-  // Identity and Access Management policies that specify the users who can
-  // create, edit, and view entries within the entry group.
-  //
-  // Data Catalog automatically creates an entry group for BigQuery entries
-  // ("@bigquery") and Pub/Sub topics ("@pubsub"). Users create their own entry
-  // group to contain Cloud Storage fileset entries or custom type entries,
-  // and the IAM policies associated with those entries. Entry groups, like
-  // entries, can be searched.
-  //
   // A maximum of 10,000 entry groups may be created per organization across all
   // locations.
   //
   // Users should enable the Data Catalog API in the project identified by
   // the `parent` parameter (see [Data Catalog Resource Project]
-  // (/data-catalog/docs/concepts/resource-project) for more information).
+  // (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+  // more information).
   rpc CreateEntryGroup(CreateEntryGroupRequest) returns (EntryGroup) {
     option (google.api.http) = {
       post: "/v1beta1/{parent=projects/*/locations/*}/entryGroups"
@@ -96,8 +87,9 @@ service DataCatalog {
 
   // Updates an EntryGroup. The user should enable the Data Catalog API in the
   // project identified by the `entry_group.name` parameter (see [Data Catalog
-  // Resource Project] (/data-catalog/docs/concepts/resource-project) for more
-  // information).
+  // Resource Project]
+  // (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+  // more information).
   rpc UpdateEntryGroup(UpdateEntryGroupRequest) returns (EntryGroup) {
     option (google.api.http) = {
       patch: "/v1beta1/{entry_group.name=projects/*/locations/*/entryGroups/*}"
@@ -119,9 +111,9 @@ service DataCatalog {
   // Deletes an EntryGroup. Only entry groups that do not contain entries can be
   // deleted. Users should enable the Data Catalog API in the project
   // identified by the `name` parameter (see [Data Catalog Resource Project]
-  // (/data-catalog/docs/concepts/resource-project) for more information).
-  rpc DeleteEntryGroup(DeleteEntryGroupRequest)
-      returns (google.protobuf.Empty) {
+  // (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+  // more information).
+  rpc DeleteEntryGroup(DeleteEntryGroupRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
       delete: "/v1beta1/{name=projects/*/locations/*/entryGroups/*}"
     };
@@ -129,8 +121,7 @@ service DataCatalog {
   }
 
   // Lists entry groups.
-  rpc ListEntryGroups(ListEntryGroupsRequest)
-      returns (ListEntryGroupsResponse) {
+  rpc ListEntryGroups(ListEntryGroupsRequest) returns (ListEntryGroupsResponse) {
     option (google.api.http) = {
       get: "/v1beta1/{parent=projects/*/locations/*}/entryGroups"
     };
@@ -142,7 +133,8 @@ service DataCatalog {
   //
   // Users should enable the Data Catalog API in the project identified by
   // the `parent` parameter (see [Data Catalog Resource Project]
-  // (/data-catalog/docs/concepts/resource-project) for more information).
+  // (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+  // more information).
   //
   // A maximum of 100,000 entries may be created per entry group.
   rpc CreateEntry(CreateEntryRequest) returns (Entry) {
@@ -156,7 +148,8 @@ service DataCatalog {
   // Updates an existing entry.
   // Users should enable the Data Catalog API in the project identified by
   // the `entry.name` parameter (see [Data Catalog Resource Project]
-  // (/data-catalog/docs/concepts/resource-project) for more information).
+  // (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+  // more information).
   rpc UpdateEntry(UpdateEntryRequest) returns (Entry) {
     option (google.api.http) = {
       patch: "/v1beta1/{entry.name=projects/*/locations/*/entryGroups/*/entries/*}"
@@ -171,7 +164,8 @@ service DataCatalog {
   // method can be deleted.
   // Users should enable the Data Catalog API in the project identified by
   // the `name` parameter (see [Data Catalog Resource Project]
-  // (/data-catalog/docs/concepts/resource-project) for more information).
+  // (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+  // more information).
   rpc DeleteEntry(DeleteEntryRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
       delete: "/v1beta1/{name=projects/*/locations/*/entryGroups/*/entries/*}"
@@ -206,15 +200,15 @@ service DataCatalog {
 
   // Creates a tag template. The user should enable the Data Catalog API in
   // the project identified by the `parent` parameter (see [Data Catalog
-  // Resource Project](/data-catalog/docs/concepts/resource-project) for more
-  // information).
+  // Resource
+  // Project](https://cloud.google.com/data-catalog/docs/concepts/resource-project)
+  // for more information).
   rpc CreateTagTemplate(CreateTagTemplateRequest) returns (TagTemplate) {
     option (google.api.http) = {
       post: "/v1beta1/{parent=projects/*/locations/*}/tagTemplates"
       body: "tag_template"
     };
-    option (google.api.method_signature) =
-        "parent,tag_template_id,tag_template";
+    option (google.api.method_signature) = "parent,tag_template_id,tag_template";
   }
 
   // Gets a tag template.
@@ -230,7 +224,8 @@ service DataCatalog {
   // and should be updated using their own create/update/delete methods.
   // Users should enable the Data Catalog API in the project identified by
   // the `tag_template.name` parameter (see [Data Catalog Resource Project]
-  // (/data-catalog/docs/concepts/resource-project) for more information).
+  // (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+  // more information).
   rpc UpdateTagTemplate(UpdateTagTemplateRequest) returns (TagTemplate) {
     option (google.api.http) = {
       patch: "/v1beta1/{tag_template.name=projects/*/locations/*/tagTemplates/*}"
@@ -243,9 +238,9 @@ service DataCatalog {
   // Deletes a tag template and all tags using the template.
   // Users should enable the Data Catalog API in the project identified by
   // the `name` parameter (see [Data Catalog Resource Project]
-  // (/data-catalog/docs/concepts/resource-project) for more information).
-  rpc DeleteTagTemplate(DeleteTagTemplateRequest)
-      returns (google.protobuf.Empty) {
+  // (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+  // more information).
+  rpc DeleteTagTemplate(DeleteTagTemplateRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
       delete: "/v1beta1/{name=projects/*/locations/*/tagTemplates/*}"
     };
@@ -255,39 +250,36 @@ service DataCatalog {
   // Creates a field in a tag template. The user should enable the Data Catalog
   // API in the project identified by the `parent` parameter (see
   // [Data Catalog Resource
-  // Project](/data-catalog/docs/concepts/resource-project) for more
-  // information).
-  rpc CreateTagTemplateField(CreateTagTemplateFieldRequest)
-      returns (TagTemplateField) {
+  // Project](https://cloud.google.com/data-catalog/docs/concepts/resource-project)
+  // for more information).
+  rpc CreateTagTemplateField(CreateTagTemplateFieldRequest) returns (TagTemplateField) {
     option (google.api.http) = {
       post: "/v1beta1/{parent=projects/*/locations/*/tagTemplates/*}/fields"
       body: "tag_template_field"
     };
-    option (google.api.method_signature) =
-        "parent,tag_template_field_id,tag_template_field";
+    option (google.api.method_signature) = "parent,tag_template_field_id,tag_template_field";
   }
 
   // Updates a field in a tag template. This method cannot be used to update the
   // field type. Users should enable the Data Catalog API in the project
   // identified by the `name` parameter (see [Data Catalog Resource Project]
-  // (/data-catalog/docs/concepts/resource-project) for more information).
-  rpc UpdateTagTemplateField(UpdateTagTemplateFieldRequest)
-      returns (TagTemplateField) {
+  // (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+  // more information).
+  rpc UpdateTagTemplateField(UpdateTagTemplateFieldRequest) returns (TagTemplateField) {
     option (google.api.http) = {
       patch: "/v1beta1/{name=projects/*/locations/*/tagTemplates/*/fields/*}"
       body: "tag_template_field"
     };
     option (google.api.method_signature) = "name,tag_template_field";
-    option (google.api.method_signature) =
-        "name,tag_template_field,update_mask";
+    option (google.api.method_signature) = "name,tag_template_field,update_mask";
   }
 
   // Renames a field in a tag template. The user should enable the Data Catalog
   // API in the project identified by the `name` parameter (see [Data Catalog
-  // Resource Project](/data-catalog/docs/concepts/resource-project) for more
-  // information).
-  rpc RenameTagTemplateField(RenameTagTemplateFieldRequest)
-      returns (TagTemplateField) {
+  // Resource
+  // Project](https://cloud.google.com/data-catalog/docs/concepts/resource-project)
+  // for more information).
+  rpc RenameTagTemplateField(RenameTagTemplateFieldRequest) returns (TagTemplateField) {
     option (google.api.http) = {
       post: "/v1beta1/{name=projects/*/locations/*/tagTemplates/*/fields/*}:rename"
       body: "*"
@@ -298,9 +290,9 @@ service DataCatalog {
   // Deletes a field in a tag template and all uses of that field.
   // Users should enable the Data Catalog API in the project identified by
   // the `name` parameter (see [Data Catalog Resource Project]
-  // (/data-catalog/docs/concepts/resource-project) for more information).
-  rpc DeleteTagTemplateField(DeleteTagTemplateFieldRequest)
-      returns (google.protobuf.Empty) {
+  // (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+  // more information).
+  rpc DeleteTagTemplateField(DeleteTagTemplateFieldRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
       delete: "/v1beta1/{name=projects/*/locations/*/tagTemplates/*/fields/*}"
     };
@@ -309,10 +301,10 @@ service DataCatalog {
 
   // Creates a tag on an [Entry][google.cloud.datacatalog.v1beta1.Entry].
   // Note: The project identified by the `parent` parameter for the
-  // [tag](/data-catalog/docs/reference/rest/v1beta1/projects.locations.entryGroups.entries.tags/create#path-parameters)
+  // [tag](https://cloud.google.com/data-catalog/docs/reference/rest/v1beta1/projects.locations.entryGroups.entries.tags/create#path-parameters)
   // and the
   // [tag
-  // template](/data-catalog/docs/reference/rest/v1beta1/projects.locations.tagTemplates/create#path-parameters)
+  // template](https://cloud.google.com/data-catalog/docs/reference/rest/v1beta1/projects.locations.tagTemplates/create#path-parameters)
   // used to create the tag must be from the same organization.
   rpc CreateTag(CreateTagRequest) returns (Tag) {
     option (google.api.http) = {
@@ -368,17 +360,15 @@ service DataCatalog {
   //   - Tag templates.
   //   - Entries.
   //   - Entry groups.
-  // Note, this method cannot be used to manage policies for BigQuery, Cloud
-  // Pub/Sub and any external Google Cloud Platform resources synced to Cloud
-  // Data Catalog.
+  // Note, this method cannot be used to manage policies for BigQuery, Pub/Sub
+  // and any external Google Cloud Platform resources synced to Data Catalog.
   //
   // Callers must have following Google IAM permission
   //   - `datacatalog.tagTemplates.setIamPolicy` to set policies on tag
   //     templates.
   //   - `datacatalog.entries.setIamPolicy` to set policies on entries.
   //   - `datacatalog.entryGroups.setIamPolicy` to set policies on entry groups.
-  rpc SetIamPolicy(google.iam.v1.SetIamPolicyRequest)
-      returns (google.iam.v1.Policy) {
+  rpc SetIamPolicy(google.iam.v1.SetIamPolicyRequest) returns (google.iam.v1.Policy) {
     option (google.api.http) = {
       post: "/v1beta1/{resource=projects/*/locations/*/tagTemplates/*}:setIamPolicy"
       body: "*"
@@ -397,17 +387,15 @@ service DataCatalog {
   //   - Tag templates.
   //   - Entries.
   //   - Entry groups.
-  // Note, this method cannot be used to manage policies for BigQuery, Cloud
-  // Pub/Sub and any external Google Cloud Platform resources synced to Cloud
-  // Data Catalog.
+  // Note, this method cannot be used to manage policies for BigQuery, Pub/Sub
+  // and any external Google Cloud Platform resources synced to Data Catalog.
   //
   // Callers must have following Google IAM permission
   //   - `datacatalog.tagTemplates.getIamPolicy` to get policies on tag
   //     templates.
   //   - `datacatalog.entries.getIamPolicy` to get policies on entries.
   //   - `datacatalog.entryGroups.getIamPolicy` to get policies on entry groups.
-  rpc GetIamPolicy(google.iam.v1.GetIamPolicyRequest)
-      returns (google.iam.v1.Policy) {
+  rpc GetIamPolicy(google.iam.v1.GetIamPolicyRequest) returns (google.iam.v1.Policy) {
     option (google.api.http) = {
       post: "/v1beta1/{resource=projects/*/locations/*/tagTemplates/*}:getIamPolicy"
       body: "*"
@@ -430,14 +418,12 @@ service DataCatalog {
   //   - Tag templates.
   //   - Entries.
   //   - Entry groups.
-  // Note, this method cannot be used to manage policies for BigQuery, Cloud
-  // Pub/Sub and any external Google Cloud Platform resources synced to Cloud
-  // Data Catalog.
+  // Note, this method cannot be used to manage policies for BigQuery, Pub/Sub
+  // and any external Google Cloud Platform resources synced to Data Catalog.
   //
   // A caller is not required to have Google IAM permission to make this
   // request.
-  rpc TestIamPermissions(google.iam.v1.TestIamPermissionsRequest)
-      returns (google.iam.v1.TestIamPermissionsResponse) {
+  rpc TestIamPermissions(google.iam.v1.TestIamPermissionsRequest) returns (google.iam.v1.TestIamPermissionsResponse) {
     option (google.api.http) = {
       post: "/v1beta1/{resource=projects/*/locations/*/tagTemplates/*}:testIamPermissions"
       body: "*"
@@ -456,19 +442,14 @@ service DataCatalog {
 // Request message for
 // [SearchCatalog][google.cloud.datacatalog.v1beta1.DataCatalog.SearchCatalog].
 message SearchCatalogRequest {
+  // The criteria that select the subspace used for query matching.
   message Scope {
-    // Data Catalog tries to automatically choose the right corpus of data to
-    // search through. You can ensure an organization is included by adding it
-    // to `include_org_ids`. You can ensure a project's org is included with
-    // `include_project_ids`. You must specify at least one organization
-    // using `include_org_ids` or `include_project_ids` in all search requests.
-    //
-    // List of organization IDs to search within. To find your organization ID,
-    // follow instructions in
+    // The list of organization IDs to search within. To find your organization
+    // ID, follow instructions in
     // https://cloud.google.com/resource-manager/docs/creating-managing-organization.
     repeated string include_org_ids = 2;
 
-    // List of project IDs to search within. To learn more about the
+    // The list of project IDs to search within. To learn more about the
     // distinction between project names/IDs/numbers, go to
     // https://cloud.google.com/docs/overview/#projects.
     repeated string include_project_ids = 3;
@@ -480,11 +461,13 @@ message SearchCatalogRequest {
     bool include_gcp_public_datasets = 7;
   }
 
-  // Required. The scope of this search request.
+  // Required. The scope of this search request. A `scope` that has empty
+  // `include_org_ids`, `include_project_ids` AND false
+  // `include_gcp_public_datasets` is considered invalid. Data Catalog will
+  // return an error in such a case.
   Scope scope = 6 [(google.api.field_behavior) = REQUIRED];
 
-  // Required. The query string in search query syntax. The query must be
-  // non-empty.
+  // Required. The query string in search query syntax. The query must be non-empty.
   //
   // Query strings can be simple as "x" or more qualified as:
   //
@@ -494,7 +477,8 @@ message SearchCatalogRequest {
   //
   // Note: Query tokens need to have a minimum of 3 characters for substring
   // matching to work correctly. See [Data Catalog Search
-  // Syntax](/data-catalog/docs/how-to/search-reference) for more information.
+  // Syntax](https://cloud.google.com/data-catalog/docs/how-to/search-reference)
+  // for more information.
   string query = 1 [(google.api.field_behavior) = REQUIRED];
 
   // Number of results in the search page. If <=0 then defaults to 10. Max limit
@@ -502,8 +486,8 @@ message SearchCatalogRequest {
   int32 page_size = 2;
 
   // Optional. Pagination token returned in an earlier
-  // [SearchCatalogResponse.next_page_token][google.cloud.datacatalog.v1beta1.SearchCatalogResponse.next_page_token],
-  // which indicates that this is a continuation of a prior
+  // [SearchCatalogResponse.next_page_token][google.cloud.datacatalog.v1beta1.SearchCatalogResponse.next_page_token], which
+  // indicates that this is a continuation of a prior
   // [SearchCatalogRequest][google.cloud.datacatalog.v1beta1.DataCatalog.SearchCatalog]
   // call, and that the system should return the next page of data. If empty,
   // the first page is returned.
@@ -601,8 +585,8 @@ message DeleteEntryGroupRequest {
 // Request message for
 // [ListEntryGroups][google.cloud.datacatalog.v1beta1.DataCatalog.ListEntryGroups].
 message ListEntryGroupsRequest {
-  // Required. The name of the location that contains the entry groups, which
-  // can be provided in URL format. Example:
+  // Required. The name of the location that contains the entry groups, which can be
+  // provided in URL format. Example:
   //
   // * projects/{project_id}/locations/{location}
   string parent = 1 [
@@ -612,12 +596,12 @@ message ListEntryGroupsRequest {
     }
   ];
 
-  // Optional. The maximum number of items to return. Default is 10. Max limit
-  // is 1000. Throws an invalid argument for `page_size > 1000`.
+  // Optional. The maximum number of items to return. Default is 10. Max limit is 1000.
+  // Throws an invalid argument for `page_size > 1000`.
   int32 page_size = 2 [(google.api.field_behavior) = OPTIONAL];
 
-  // Optional. Token that specifies which page is requested. If empty, the first
-  // page is returned.
+  // Optional. Token that specifies which page is requested. If empty, the first page is
+  // returned.
   string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
@@ -733,7 +717,7 @@ message LookupEntryRequest {
     //
     // Examples:
     //
-    //   * `cloud_pubsub.project_id.topic_id`
+    //   * `pubsub.project_id.topic_id`
     //   * ``pubsub.project_id.`topic.id.with.dots` ``
     //   * `bigquery.table.project_id.dataset_id.table_id`
     //   * `bigquery.dataset.project_id.dataset_id`
@@ -747,7 +731,7 @@ message LookupEntryRequest {
 
 // Entry Metadata.
 // A Data Catalog Entry resource represents another resource in Google
-// Cloud Platform (such as a BigQuery dataset or a Cloud Pub/Sub topic), or
+// Cloud Platform (such as a BigQuery dataset or a Pub/Sub topic), or
 // outside of Google Cloud Platform. Clients can use the `linked_resource` field
 // in the Entry resource to refer to the original resource ID of the source
 // system.
@@ -768,8 +752,8 @@ message Entry {
   // Note that this Entry and its child resources may not actually be stored in
   // the location in this name.
   string name = 1 [(google.api.resource_reference) = {
-    type: "datacatalog.googleapis.com/EntryGroup"
-  }];
+                     type: "datacatalog.googleapis.com/EntryGroup"
+                   }];
 
   // The resource this metadata entry refers to.
   //
@@ -806,10 +790,9 @@ message Entry {
 
   // The source system of the entry.
   oneof system {
-    // Output only. This field indicates the entry's source system that Data
-    // Catalog integrates with, such as BigQuery or Cloud Pub/Sub.
-    IntegratedSystem integrated_system = 17
-        [(google.api.field_behavior) = OUTPUT_ONLY];
+    // Output only. This field indicates the entry's source system that Data Catalog
+    // integrates with, such as BigQuery or Pub/Sub.
+    IntegratedSystem integrated_system = 17 [(google.api.field_behavior) = OUTPUT_ONLY];
 
     // This field indicates the entry's source system that Data Catalog does not
     // integrate with. `user_specified_system` strings must begin with a letter
@@ -847,12 +830,11 @@ message Entry {
   // Schema of the entry. An entry might not have any schema attached to it.
   Schema schema = 5;
 
-  // Output only. Timestamps about the underlying resource, not about this Data
-  // Catalog entry. Output only when Entry is of type in the EntryType enum. For
-  // entries with user_specified_type, this field is optional and defaults to an
-  // empty timestamp.
-  SystemTimestamps source_system_timestamps = 7
-      [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Output only. Timestamps about the underlying resource, not about this Data Catalog
+  // entry. Output only when Entry is of type in the EntryType enum. For entries
+  // with user_specified_type, this field is optional and defaults to an empty
+  // timestamp.
+  SystemTimestamps source_system_timestamps = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // EntryGroup Metadata.
@@ -881,18 +863,15 @@ message EntryGroup {
   // string.
   string description = 3;
 
-  // Output only. Timestamps about this EntryGroup. Default value is empty
-  // timestamps.
-  SystemTimestamps data_catalog_timestamps = 4
-      [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Output only. Timestamps about this EntryGroup. Default value is empty timestamps.
+  SystemTimestamps data_catalog_timestamps = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // Request message for
 // [CreateTagTemplate][google.cloud.datacatalog.v1beta1.DataCatalog.CreateTagTemplate].
 message CreateTagTemplateRequest {
   // Required. The name of the project and the template location
-  // [region](/compute/docs/regions-zones/#available).
-  // NOTE: Currently, only the `us-central1 region` is supported.
+  // [region](https://cloud.google.com/data-catalog/docs/concepts/regions.
   //
   // Example:
   //
@@ -909,29 +888,6 @@ message CreateTagTemplateRequest {
 
   // Required. The tag template to create.
   TagTemplate tag_template = 2 [(google.api.field_behavior) = REQUIRED];
-}
-
-// Entry resources in Data Catalog can be of different types e.g. a BigQuery
-// Table entry is of type `TABLE`. This enum describes all the possible types
-// Data Catalog contains.
-enum EntryType {
-  // Default unknown type
-  ENTRY_TYPE_UNSPECIFIED = 0;
-
-  // Output only. The type of entry that has a GoogleSQL schema, including
-  // logical views.
-  TABLE = 2;
-
-  // Output only. The type of models.
-  MODEL = 5;
-
-  // Output only. An entry type which is used for streaming entries. Example:
-  // Cloud Pub/Sub topic.
-  DATA_STREAM = 3;
-
-  // An entry type which is a set of files or objects. Example:
-  // Cloud Storage fileset.
-  FILESET = 4;
 }
 
 // Request message for
@@ -986,8 +942,8 @@ message DeleteTagTemplateRequest {
 // Request message for
 // [CreateTag][google.cloud.datacatalog.v1beta1.DataCatalog.CreateTag].
 message CreateTagRequest {
-  // Required. The name of the resource to attach this tag to. Tags can be
-  // attached to Entries. Example:
+  // Required. The name of the resource to attach this tag to. Tags can be attached to
+  // Entries. Example:
   //
   // * projects/{project_id}/locations/{location}/entryGroups/{entry_group_id}/entries/{entry_id}
   //
@@ -995,7 +951,9 @@ message CreateTagRequest {
   // the location in this name.
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = { type: "datacatalog.googleapis.com/Tag" }
+    (google.api.resource_reference) = {
+      type: "datacatalog.googleapis.com/Tag"
+    }
   ];
 
   // Required. The tag to create.
@@ -1031,8 +989,7 @@ message DeleteTagRequest {
 // [CreateTagTemplateField][google.cloud.datacatalog.v1beta1.DataCatalog.CreateTagTemplateField].
 message CreateTagTemplateFieldRequest {
   // Required. The name of the project and the template location
-  // [region](/compute/docs/regions-zones/#available).
-  // NOTE: Currently, only the `us-central1 region` is supported.
+  // [region](https://cloud.google.com/data-catalog/docs/concepts/regions).
   //
   // Example:
   //
@@ -1052,8 +1009,7 @@ message CreateTagTemplateFieldRequest {
   string tag_template_field_id = 2 [(google.api.field_behavior) = REQUIRED];
 
   // Required. The tag template field to create.
-  TagTemplateField tag_template_field = 3
-      [(google.api.field_behavior) = REQUIRED];
+  TagTemplateField tag_template_field = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
 // Request message for
@@ -1070,8 +1026,7 @@ message UpdateTagTemplateFieldRequest {
   ];
 
   // Required. The template to update.
-  TagTemplateField tag_template_field = 2
-      [(google.api.field_behavior) = REQUIRED];
+  TagTemplateField tag_template_field = 2 [(google.api.field_behavior) = REQUIRED];
 
   // Optional. The field mask specifies the parts of the template to be updated.
   // Allowed fields:
@@ -1087,8 +1042,7 @@ message UpdateTagTemplateFieldRequest {
   // existing values. Therefore, enum values can only be added, existing enum
   // values cannot be deleted nor renamed. Updating a template field from
   // optional to required is NOT allowed.
-  google.protobuf.FieldMask update_mask = 3
-      [(google.api.field_behavior) = OPTIONAL];
+  google.protobuf.FieldMask update_mask = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Request message for
@@ -1104,8 +1058,7 @@ message RenameTagTemplateFieldRequest {
     }
   ];
 
-  // Required. The new ID of this tag template field. For example,
-  // `my_new_field`.
+  // Required. The new ID of this tag template field. For example, `my_new_field`.
   string new_tag_template_field_id = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
@@ -1131,8 +1084,8 @@ message DeleteTagTemplateFieldRequest {
 // Request message for
 // [ListTags][google.cloud.datacatalog.v1beta1.DataCatalog.ListTags].
 message ListTagsRequest {
-  // Required. The name of the Data Catalog resource to list the tags of. The
-  // resource could be an [Entry][google.cloud.datacatalog.v1beta1.Entry] or an
+  // Required. The name of the Data Catalog resource to list the tags of. The resource
+  // could be an [Entry][google.cloud.datacatalog.v1beta1.Entry] or an
   // [EntryGroup][google.cloud.datacatalog.v1beta1.EntryGroup].
   //
   // Examples:
@@ -1203,4 +1156,28 @@ message ListEntriesResponse {
   // Token to retrieve the next page of results. It is set to empty if no items
   // remain in results.
   string next_page_token = 2;
+}
+
+// Entry resources in Data Catalog can be of different types e.g. a BigQuery
+// Table entry is of type `TABLE`. This enum describes all the possible types
+// Data Catalog contains.
+enum EntryType {
+  // Default unknown type.
+  ENTRY_TYPE_UNSPECIFIED = 0;
+
+  // Output only. The type of entry that has a GoogleSQL schema, including
+  // logical views.
+  TABLE = 2;
+
+  // Output only. The type of models.
+  // https://cloud.google.com/bigquery-ml/docs/bigqueryml-intro
+  MODEL = 5;
+
+  // Output only. An entry type which is used for streaming entries. Example:
+  // Pub/Sub topic.
+  DATA_STREAM = 3;
+
+  // An entry type which is a set of files or objects. Example:
+  // Cloud Storage fileset.
+  FILESET = 4;
 }

--- a/protos/google/cloud/datacatalog/v1beta1/gcs_fileset_spec.proto
+++ b/protos/google/cloud/datacatalog/v1beta1/gcs_fileset_spec.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
@@ -21,9 +20,12 @@ import "google/api/field_behavior.proto";
 import "google/cloud/datacatalog/v1beta1/timestamps.proto";
 
 option cc_enable_arenas = true;
+option csharp_namespace = "Google.Cloud.DataCatalog.V1Beta1";
 option go_package = "google.golang.org/genproto/googleapis/cloud/datacatalog/v1beta1;datacatalog";
 option java_multiple_files = true;
 option java_package = "com.google.cloud.datacatalog.v1beta1";
+option php_namespace = "Google\\Cloud\\DataCatalog\\V1beta1";
+option ruby_package = "Google::Cloud::DataCatalog::V1beta1";
 
 // Describes a Cloud Storage fileset entry.
 message GcsFilesetSpec {

--- a/protos/google/cloud/datacatalog/v1beta1/policytagmanager.proto
+++ b/protos/google/cloud/datacatalog/v1beta1/policytagmanager.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
@@ -28,10 +27,13 @@ import "google/protobuf/empty.proto";
 import "google/protobuf/field_mask.proto";
 
 option cc_enable_arenas = true;
+option csharp_namespace = "Google.Cloud.DataCatalog.V1Beta1";
 option go_package = "google.golang.org/genproto/googleapis/cloud/datacatalog/v1beta1;datacatalog";
 option java_multiple_files = true;
 option java_outer_classname = "PolicyTagManagerProto";
 option java_package = "com.google.cloud.datacatalog.v1beta1";
+option php_namespace = "Google\\Cloud\\DataCatalog\\V1beta1";
+option ruby_package = "Google::Cloud::DataCatalog::V1beta1";
 
 // The policy tag manager API service allows clients to manage their taxonomies
 // and policy tags.

--- a/protos/google/cloud/datacatalog/v1beta1/policytagmanagerserialization.proto
+++ b/protos/google/cloud/datacatalog/v1beta1/policytagmanagerserialization.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
@@ -25,10 +24,13 @@ import "google/iam/v1/policy.proto";
 import "google/api/client.proto";
 
 option cc_enable_arenas = true;
+option csharp_namespace = "Google.Cloud.DataCatalog.V1Beta1";
 option go_package = "google.golang.org/genproto/googleapis/cloud/datacatalog/v1beta1;datacatalog";
 option java_multiple_files = true;
 option java_outer_classname = "PolicyTagManagerSerializationProto";
 option java_package = "com.google.cloud.datacatalog.v1beta1";
+option php_namespace = "Google\\Cloud\\DataCatalog\\V1beta1";
+option ruby_package = "Google::Cloud::DataCatalog::V1beta1";
 
 // Policy tag manager serialization API service allows clients to manipulate
 // their taxonomies and policy tags data with serialized format.

--- a/protos/google/cloud/datacatalog/v1beta1/schema.proto
+++ b/protos/google/cloud/datacatalog/v1beta1/schema.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
@@ -20,9 +19,12 @@ package google.cloud.datacatalog.v1beta1;
 import "google/api/field_behavior.proto";
 
 option cc_enable_arenas = true;
+option csharp_namespace = "Google.Cloud.DataCatalog.V1Beta1";
 option go_package = "google.golang.org/genproto/googleapis/cloud/datacatalog/v1beta1;datacatalog";
 option java_multiple_files = true;
 option java_package = "com.google.cloud.datacatalog.v1beta1";
+option php_namespace = "Google\\Cloud\\DataCatalog\\V1beta1";
+option ruby_package = "Google::Cloud::DataCatalog::V1beta1";
 
 // Represents a schema (e.g. BigQuery, GoogleSQL, Avro schema).
 message Schema {

--- a/protos/google/cloud/datacatalog/v1beta1/search.proto
+++ b/protos/google/cloud/datacatalog/v1beta1/search.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
@@ -22,9 +21,12 @@ import "google/cloud/datacatalog/v1beta1/common.proto";
 import "google/protobuf/timestamp.proto";
 
 option cc_enable_arenas = true;
+option csharp_namespace = "Google.Cloud.DataCatalog.V1Beta1";
 option go_package = "google.golang.org/genproto/googleapis/cloud/datacatalog/v1beta1;datacatalog";
 option java_multiple_files = true;
 option java_package = "com.google.cloud.datacatalog.v1beta1";
+option php_namespace = "Google\\Cloud\\DataCatalog\\V1beta1";
+option ruby_package = "Google::Cloud::DataCatalog::V1beta1";
 
 // A result that appears in the response of a search request. Each result
 // captures details of one entry that matches the search.

--- a/protos/google/cloud/datacatalog/v1beta1/table_spec.proto
+++ b/protos/google/cloud/datacatalog/v1beta1/table_spec.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
@@ -21,9 +20,12 @@ import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 
 option cc_enable_arenas = true;
+option csharp_namespace = "Google.Cloud.DataCatalog.V1Beta1";
 option go_package = "google.golang.org/genproto/googleapis/cloud/datacatalog/v1beta1;datacatalog";
 option java_multiple_files = true;
 option java_package = "com.google.cloud.datacatalog.v1beta1";
+option php_namespace = "Google\\Cloud\\DataCatalog\\V1beta1";
+option ruby_package = "Google::Cloud::DataCatalog::V1beta1";
 
 // Describes a BigQuery table.
 message BigQueryTableSpec {

--- a/protos/google/cloud/datacatalog/v1beta1/tags.proto
+++ b/protos/google/cloud/datacatalog/v1beta1/tags.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
@@ -22,15 +21,19 @@ import "google/api/resource.proto";
 import "google/protobuf/timestamp.proto";
 
 option cc_enable_arenas = true;
+option csharp_namespace = "Google.Cloud.DataCatalog.V1Beta1";
 option go_package = "google.golang.org/genproto/googleapis/cloud/datacatalog/v1beta1;datacatalog";
 option java_multiple_files = true;
 option java_package = "com.google.cloud.datacatalog.v1beta1";
+option php_namespace = "Google\\Cloud\\DataCatalog\\V1beta1";
+option ruby_package = "Google::Cloud::DataCatalog::V1beta1";
 
 // Tags are used to attach custom metadata to Data Catalog resources. Tags
 // conform to the specifications within their tag template.
 //
-// See [Data Catalog IAM](/data-catalog/docs/concepts/iam) for information on
-// the permissions needed to create or view tags.
+// See [Data Catalog
+// IAM](https://cloud.google.com/data-catalog/docs/concepts/iam) for information
+// on the permissions needed to create or view tags.
 message Tag {
   option (google.api.resource) = {
     type: "datacatalog.googleapis.com/Tag"
@@ -106,14 +109,23 @@ message TagField {
     // one of the allowed values in the definition of this enum.
     EnumValue enum_value = 6;
   }
+
+  // Output only. The order of this field with respect to other fields in this tag. It can be
+  // set in [Tag][google.cloud.datacatalog.v1beta1.TagTemplateField.order]. For
+  // example, a higher value can indicate a more important field. The value can
+  // be negative. Multiple fields can have the same order, and field orders
+  // within a tag do not have to be sequential.
+  int32 order = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // A tag template defines a tag, which can have one or more typed fields.
 // The template is used to create and attach the tag to GCP resources.
-// [Tag template roles](/iam/docs/understanding-roles#data-catalog-roles)
-// provide permissions to create, edit, and use the template (see, for example,
-// the [TagTemplate User](/data-catalog/docs/how-to/template-user) role, which
-// includes permission to use the tag template to tag resources.
+// [Tag template
+// roles](https://cloud.google.com/iam/docs/understanding-roles#data-catalog-roles)
+// provide permissions to create, edit, and use the template. See, for example,
+// the [TagTemplate
+// User](https://cloud.google.com/data-catalog/docs/how-to/template-user) role,
+// which includes permission to use the tag template to tag resources.
 message TagTemplate {
   option (google.api.resource) = {
     type: "datacatalog.googleapis.com/TagTemplate"
@@ -165,6 +177,12 @@ message TagTemplateField {
 
   // Whether this is a required field. Defaults to false.
   bool is_required = 3;
+
+  // The order of this field with respect to other fields in this tag
+  // template.  A higher value indicates a more important field. The value can
+  // be negative. Multiple fields can have the same order, and field orders
+  // within a tag do not have to be sequential.
+  int32 order = 5;
 }
 
 message FieldType {

--- a/protos/google/cloud/datacatalog/v1beta1/timestamps.proto
+++ b/protos/google/cloud/datacatalog/v1beta1/timestamps.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
@@ -21,9 +20,12 @@ import "google/api/field_behavior.proto";
 import "google/protobuf/timestamp.proto";
 
 option cc_enable_arenas = true;
+option csharp_namespace = "Google.Cloud.DataCatalog.V1Beta1";
 option go_package = "google.golang.org/genproto/googleapis/cloud/datacatalog/v1beta1;datacatalog";
 option java_multiple_files = true;
 option java_package = "com.google.cloud.datacatalog.v1beta1";
+option php_namespace = "Google\\Cloud\\DataCatalog\\V1beta1";
+option ruby_package = "Google::Cloud::DataCatalog::V1beta1";
 
 // Timestamps about this resource according to a particular system.
 message SystemTimestamps {

--- a/protos/protos.d.ts
+++ b/protos/protos.d.ts
@@ -8009,15 +8009,6 @@ export namespace google {
                     public toJSON(): { [k: string]: any };
                 }
 
-                /** EntryType enum. */
-                enum EntryType {
-                    ENTRY_TYPE_UNSPECIFIED = 0,
-                    TABLE = 2,
-                    MODEL = 5,
-                    DATA_STREAM = 3,
-                    FILESET = 4
-                }
-
                 /** Properties of a GetTagTemplateRequest. */
                 interface IGetTagTemplateRequest {
 
@@ -9380,6 +9371,15 @@ export namespace google {
                     public toJSON(): { [k: string]: any };
                 }
 
+                /** EntryType enum. */
+                enum EntryType {
+                    ENTRY_TYPE_UNSPECIFIED = 0,
+                    TABLE = 2,
+                    MODEL = 5,
+                    DATA_STREAM = 3,
+                    FILESET = 4
+                }
+
                 /** Properties of a GcsFilesetSpec. */
                 interface IGcsFilesetSpec {
 
@@ -10531,6 +10531,9 @@ export namespace google {
 
                     /** TagField enumValue */
                     enumValue?: (google.cloud.datacatalog.v1beta1.TagField.IEnumValue|null);
+
+                    /** TagField order */
+                    order?: (number|null);
                 }
 
                 /** Represents a TagField. */
@@ -10559,6 +10562,9 @@ export namespace google {
 
                     /** TagField enumValue. */
                     public enumValue?: (google.cloud.datacatalog.v1beta1.TagField.IEnumValue|null);
+
+                    /** TagField order. */
+                    public order: number;
 
                     /** TagField kind. */
                     public kind?: ("doubleValue"|"stringValue"|"boolValue"|"timestampValue"|"enumValue");
@@ -10843,6 +10849,9 @@ export namespace google {
 
                     /** TagTemplateField isRequired */
                     isRequired?: (boolean|null);
+
+                    /** TagTemplateField order */
+                    order?: (number|null);
                 }
 
                 /** Represents a TagTemplateField. */
@@ -10865,6 +10874,9 @@ export namespace google {
 
                     /** TagTemplateField isRequired. */
                     public isRequired: boolean;
+
+                    /** TagTemplateField order. */
+                    public order: number;
 
                     /**
                      * Creates a new TagTemplateField instance using the specified properties.

--- a/protos/protos.js
+++ b/protos/protos.js
@@ -28,7 +28,7 @@
     var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
     
     // Exported root namespace
-    var $root = $protobuf.roots._google_cloud_datacatalog_1_8_0_protos || ($protobuf.roots._google_cloud_datacatalog_1_8_0_protos = {});
+    var $root = $protobuf.roots._google_cloud_datacatalog_2_0_0_protos || ($protobuf.roots._google_cloud_datacatalog_2_0_0_protos = {});
     
     $root.google = (function() {
     
@@ -18377,26 +18377,6 @@
                         return CreateTagTemplateRequest;
                     })();
     
-                    /**
-                     * EntryType enum.
-                     * @name google.cloud.datacatalog.v1beta1.EntryType
-                     * @enum {string}
-                     * @property {number} ENTRY_TYPE_UNSPECIFIED=0 ENTRY_TYPE_UNSPECIFIED value
-                     * @property {number} TABLE=2 TABLE value
-                     * @property {number} MODEL=5 MODEL value
-                     * @property {number} DATA_STREAM=3 DATA_STREAM value
-                     * @property {number} FILESET=4 FILESET value
-                     */
-                    v1beta1.EntryType = (function() {
-                        var valuesById = {}, values = Object.create(valuesById);
-                        values[valuesById[0] = "ENTRY_TYPE_UNSPECIFIED"] = 0;
-                        values[valuesById[2] = "TABLE"] = 2;
-                        values[valuesById[5] = "MODEL"] = 5;
-                        values[valuesById[3] = "DATA_STREAM"] = 3;
-                        values[valuesById[4] = "FILESET"] = 4;
-                        return values;
-                    })();
-    
                     v1beta1.GetTagTemplateRequest = (function() {
     
                         /**
@@ -21488,6 +21468,26 @@
                         return ListEntriesResponse;
                     })();
     
+                    /**
+                     * EntryType enum.
+                     * @name google.cloud.datacatalog.v1beta1.EntryType
+                     * @enum {string}
+                     * @property {number} ENTRY_TYPE_UNSPECIFIED=0 ENTRY_TYPE_UNSPECIFIED value
+                     * @property {number} TABLE=2 TABLE value
+                     * @property {number} MODEL=5 MODEL value
+                     * @property {number} DATA_STREAM=3 DATA_STREAM value
+                     * @property {number} FILESET=4 FILESET value
+                     */
+                    v1beta1.EntryType = (function() {
+                        var valuesById = {}, values = Object.create(valuesById);
+                        values[valuesById[0] = "ENTRY_TYPE_UNSPECIFIED"] = 0;
+                        values[valuesById[2] = "TABLE"] = 2;
+                        values[valuesById[5] = "MODEL"] = 5;
+                        values[valuesById[3] = "DATA_STREAM"] = 3;
+                        values[valuesById[4] = "FILESET"] = 4;
+                        return values;
+                    })();
+    
                     v1beta1.GcsFilesetSpec = (function() {
     
                         /**
@@ -24292,6 +24292,7 @@
                          * @property {boolean|null} [boolValue] TagField boolValue
                          * @property {google.protobuf.ITimestamp|null} [timestampValue] TagField timestampValue
                          * @property {google.cloud.datacatalog.v1beta1.TagField.IEnumValue|null} [enumValue] TagField enumValue
+                         * @property {number|null} [order] TagField order
                          */
     
                         /**
@@ -24357,6 +24358,14 @@
                          */
                         TagField.prototype.enumValue = null;
     
+                        /**
+                         * TagField order.
+                         * @member {number} order
+                         * @memberof google.cloud.datacatalog.v1beta1.TagField
+                         * @instance
+                         */
+                        TagField.prototype.order = 0;
+    
                         // OneOf field names bound to virtual getters and setters
                         var $oneOfFields;
     
@@ -24407,6 +24416,8 @@
                                 $root.google.protobuf.Timestamp.encode(message.timestampValue, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
                             if (message.enumValue != null && message.hasOwnProperty("enumValue"))
                                 $root.google.cloud.datacatalog.v1beta1.TagField.EnumValue.encode(message.enumValue, writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
+                            if (message.order != null && message.hasOwnProperty("order"))
+                                writer.uint32(/* id 7, wireType 0 =*/56).int32(message.order);
                             return writer;
                         };
     
@@ -24458,6 +24469,9 @@
                                     break;
                                 case 6:
                                     message.enumValue = $root.google.cloud.datacatalog.v1beta1.TagField.EnumValue.decode(reader, reader.uint32());
+                                    break;
+                                case 7:
+                                    message.order = reader.int32();
                                     break;
                                 default:
                                     reader.skipType(tag & 7);
@@ -24537,6 +24551,9 @@
                                         return "enumValue." + error;
                                 }
                             }
+                            if (message.order != null && message.hasOwnProperty("order"))
+                                if (!$util.isInteger(message.order))
+                                    return "order: integer expected";
                             return null;
                         };
     
@@ -24570,6 +24587,8 @@
                                     throw TypeError(".google.cloud.datacatalog.v1beta1.TagField.enumValue: object expected");
                                 message.enumValue = $root.google.cloud.datacatalog.v1beta1.TagField.EnumValue.fromObject(object.enumValue);
                             }
+                            if (object.order != null)
+                                message.order = object.order | 0;
                             return message;
                         };
     
@@ -24586,8 +24605,10 @@
                             if (!options)
                                 options = {};
                             var object = {};
-                            if (options.defaults)
+                            if (options.defaults) {
                                 object.displayName = "";
+                                object.order = 0;
+                            }
                             if (message.displayName != null && message.hasOwnProperty("displayName"))
                                 object.displayName = message.displayName;
                             if (message.doubleValue != null && message.hasOwnProperty("doubleValue")) {
@@ -24615,6 +24636,8 @@
                                 if (options.oneofs)
                                     object.kind = "enumValue";
                             }
+                            if (message.order != null && message.hasOwnProperty("order"))
+                                object.order = message.order;
                             return object;
                         };
     
@@ -25090,6 +25113,7 @@
                          * @property {string|null} [displayName] TagTemplateField displayName
                          * @property {google.cloud.datacatalog.v1beta1.IFieldType|null} [type] TagTemplateField type
                          * @property {boolean|null} [isRequired] TagTemplateField isRequired
+                         * @property {number|null} [order] TagTemplateField order
                          */
     
                         /**
@@ -25140,6 +25164,14 @@
                         TagTemplateField.prototype.isRequired = false;
     
                         /**
+                         * TagTemplateField order.
+                         * @member {number} order
+                         * @memberof google.cloud.datacatalog.v1beta1.TagTemplateField
+                         * @instance
+                         */
+                        TagTemplateField.prototype.order = 0;
+    
+                        /**
                          * Creates a new TagTemplateField instance using the specified properties.
                          * @function create
                          * @memberof google.cloud.datacatalog.v1beta1.TagTemplateField
@@ -25169,6 +25201,8 @@
                                 $root.google.cloud.datacatalog.v1beta1.FieldType.encode(message.type, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
                             if (message.isRequired != null && message.hasOwnProperty("isRequired"))
                                 writer.uint32(/* id 3, wireType 0 =*/24).bool(message.isRequired);
+                            if (message.order != null && message.hasOwnProperty("order"))
+                                writer.uint32(/* id 5, wireType 0 =*/40).int32(message.order);
                             if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 6, wireType 2 =*/50).string(message.name);
                             return writer;
@@ -25216,6 +25250,9 @@
                                     break;
                                 case 3:
                                     message.isRequired = reader.bool();
+                                    break;
+                                case 5:
+                                    message.order = reader.int32();
                                     break;
                                 default:
                                     reader.skipType(tag & 7);
@@ -25266,6 +25303,9 @@
                             if (message.isRequired != null && message.hasOwnProperty("isRequired"))
                                 if (typeof message.isRequired !== "boolean")
                                     return "isRequired: boolean expected";
+                            if (message.order != null && message.hasOwnProperty("order"))
+                                if (!$util.isInteger(message.order))
+                                    return "order: integer expected";
                             return null;
                         };
     
@@ -25292,6 +25332,8 @@
                             }
                             if (object.isRequired != null)
                                 message.isRequired = Boolean(object.isRequired);
+                            if (object.order != null)
+                                message.order = object.order | 0;
                             return message;
                         };
     
@@ -25312,6 +25354,7 @@
                                 object.displayName = "";
                                 object.type = null;
                                 object.isRequired = false;
+                                object.order = 0;
                                 object.name = "";
                             }
                             if (message.displayName != null && message.hasOwnProperty("displayName"))
@@ -25320,6 +25363,8 @@
                                 object.type = $root.google.cloud.datacatalog.v1beta1.FieldType.toObject(message.type, options);
                             if (message.isRequired != null && message.hasOwnProperty("isRequired"))
                                 object.isRequired = message.isRequired;
+                            if (message.order != null && message.hasOwnProperty("order"))
+                                object.order = message.order;
                             if (message.name != null && message.hasOwnProperty("name"))
                                 object.name = message.name;
                             return object;

--- a/protos/protos.json
+++ b/protos/protos.json
@@ -1414,9 +1414,12 @@
                 "v1beta1": {
                   "options": {
                     "cc_enable_arenas": true,
+                    "csharp_namespace": "Google.Cloud.DataCatalog.V1Beta1",
                     "go_package": "google.golang.org/genproto/googleapis/cloud/datacatalog/v1beta1;datacatalog",
                     "java_multiple_files": true,
                     "java_package": "com.google.cloud.datacatalog.v1beta1",
+                    "php_namespace": "Google\\Cloud\\DataCatalog\\V1beta1",
+                    "ruby_package": "Google::Cloud::DataCatalog::V1beta1",
                     "java_outer_classname": "PolicyTagManagerSerializationProto"
                   },
                   "nested": {
@@ -2080,15 +2083,6 @@
                         }
                       }
                     },
-                    "EntryType": {
-                      "values": {
-                        "ENTRY_TYPE_UNSPECIFIED": 0,
-                        "TABLE": 2,
-                        "MODEL": 5,
-                        "DATA_STREAM": 3,
-                        "FILESET": 4
-                      }
-                    },
                     "GetTagTemplateRequest": {
                       "fields": {
                         "name": {
@@ -2339,6 +2333,15 @@
                           "type": "string",
                           "id": 2
                         }
+                      }
+                    },
+                    "EntryType": {
+                      "values": {
+                        "ENTRY_TYPE_UNSPECIFIED": 0,
+                        "TABLE": 2,
+                        "MODEL": 5,
+                        "DATA_STREAM": 3,
+                        "FILESET": 4
                       }
                     },
                     "GcsFilesetSpec": {
@@ -2652,6 +2655,13 @@
                         "enumValue": {
                           "type": "EnumValue",
                           "id": 6
+                        },
+                        "order": {
+                          "type": "int32",
+                          "id": 7,
+                          "options": {
+                            "(google.api.field_behavior)": "OUTPUT_ONLY"
+                          }
                         }
                       },
                       "nested": {
@@ -2716,6 +2726,10 @@
                         "isRequired": {
                           "type": "bool",
                           "id": 3
+                        },
+                        "order": {
+                          "type": "int32",
+                          "id": 5
                         }
                       }
                     },

--- a/src/v1beta1/data_catalog_client.ts
+++ b/src/v1beta1/data_catalog_client.ts
@@ -399,24 +399,13 @@ export class DataCatalogClient {
     >
   ): void;
   /**
-   * Creates an EntryGroup.
-   *
-   * An entry group contains logically related entries together with Cloud
-   * Identity and Access Management policies that specify the users who can
-   * create, edit, and view entries within the entry group.
-   *
-   * Data Catalog automatically creates an entry group for BigQuery entries
-   * ("@bigquery") and Pub/Sub topics ("@pubsub"). Users create their own entry
-   * group to contain Cloud Storage fileset entries or custom type entries,
-   * and the IAM policies associated with those entries. Entry groups, like
-   * entries, can be searched.
-   *
    * A maximum of 10,000 entry groups may be created per organization across all
    * locations.
    *
    * Users should enable the Data Catalog API in the project identified by
    * the `parent` parameter (see [Data Catalog Resource Project]
-   * (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for more information).
+   * (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+   * more information).
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -523,8 +512,9 @@ export class DataCatalogClient {
   /**
    * Updates an EntryGroup. The user should enable the Data Catalog API in the
    * project identified by the `entry_group.name` parameter (see [Data Catalog
-   * Resource Project] (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for more
-   * information).
+   * Resource Project]
+   * (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+   * more information).
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -715,7 +705,8 @@ export class DataCatalogClient {
    * Deletes an EntryGroup. Only entry groups that do not contain entries can be
    * deleted. Users should enable the Data Catalog API in the project
    * identified by the `name` parameter (see [Data Catalog Resource Project]
-   * (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for more information).
+   * (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+   * more information).
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -814,7 +805,8 @@ export class DataCatalogClient {
    *
    * Users should enable the Data Catalog API in the project identified by
    * the `parent` parameter (see [Data Catalog Resource Project]
-   * (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for more information).
+   * (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+   * more information).
    *
    * A maximum of 100,000 entries may be created per entry group.
    *
@@ -916,7 +908,8 @@ export class DataCatalogClient {
    * Updates an existing entry.
    * Users should enable the Data Catalog API in the project identified by
    * the `entry.name` parameter (see [Data Catalog Resource Project]
-   * (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for more information).
+   * (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+   * more information).
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -1030,7 +1023,8 @@ export class DataCatalogClient {
    * method can be deleted.
    * Users should enable the Data Catalog API in the project identified by
    * the `name` parameter (see [Data Catalog Resource Project]
-   * (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for more information).
+   * (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+   * more information).
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -1231,7 +1225,7 @@ export class DataCatalogClient {
    *
    *   Examples:
    *
-   *     * `cloud_pubsub.project_id.topic_id`
+   *     * `pubsub.project_id.topic_id`
    *     * ``pubsub.project_id.`topic.id.with.dots` ``
    *     * `bigquery.table.project_id.dataset_id.table_id`
    *     * `bigquery.dataset.project_id.dataset_id`
@@ -1319,15 +1313,15 @@ export class DataCatalogClient {
   /**
    * Creates a tag template. The user should enable the Data Catalog API in
    * the project identified by the `parent` parameter (see [Data Catalog
-   * Resource Project](https://cloud.google.com/data-catalog/docs/concepts/resource-project) for more
-   * information).
+   * Resource
+   * Project](https://cloud.google.com/data-catalog/docs/concepts/resource-project)
+   * for more information).
    *
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.parent
    *   Required. The name of the project and the template location
-   *   [region](https://cloud.google.com/compute/docs/regions-zones/#available).
-   *   NOTE: Currently, only the `us-central1 region` is supported.
+   *   [region](https://cloud.google.com/data-catalog/docs/concepts/regions.
    *
    *   Example:
    *
@@ -1525,7 +1519,8 @@ export class DataCatalogClient {
    * and should be updated using their own create/update/delete methods.
    * Users should enable the Data Catalog API in the project identified by
    * the `tag_template.name` parameter (see [Data Catalog Resource Project]
-   * (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for more information).
+   * (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+   * more information).
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -1630,7 +1625,8 @@ export class DataCatalogClient {
    * Deletes a tag template and all tags using the template.
    * Users should enable the Data Catalog API in the project identified by
    * the `name` parameter (see [Data Catalog Resource Project]
-   * (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for more information).
+   * (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+   * more information).
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -1733,15 +1729,14 @@ export class DataCatalogClient {
    * Creates a field in a tag template. The user should enable the Data Catalog
    * API in the project identified by the `parent` parameter (see
    * [Data Catalog Resource
-   * Project](https://cloud.google.com/data-catalog/docs/concepts/resource-project) for more
-   * information).
+   * Project](https://cloud.google.com/data-catalog/docs/concepts/resource-project)
+   * for more information).
    *
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.parent
    *   Required. The name of the project and the template location
-   *   [region](https://cloud.google.com/compute/docs/regions-zones/#available).
-   *   NOTE: Currently, only the `us-central1 region` is supported.
+   *   [region](https://cloud.google.com/data-catalog/docs/concepts/regions).
    *
    *   Example:
    *
@@ -1849,7 +1844,8 @@ export class DataCatalogClient {
    * Updates a field in a tag template. This method cannot be used to update the
    * field type. Users should enable the Data Catalog API in the project
    * identified by the `name` parameter (see [Data Catalog Resource Project]
-   * (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for more information).
+   * (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+   * more information).
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -1968,8 +1964,9 @@ export class DataCatalogClient {
   /**
    * Renames a field in a tag template. The user should enable the Data Catalog
    * API in the project identified by the `name` parameter (see [Data Catalog
-   * Resource Project](https://cloud.google.com/data-catalog/docs/concepts/resource-project) for more
-   * information).
+   * Resource
+   * Project](https://cloud.google.com/data-catalog/docs/concepts/resource-project)
+   * for more information).
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -1978,8 +1975,7 @@ export class DataCatalogClient {
    *
    *   * projects/{project_id}/locations/{location}/tagTemplates/{tag_template_id}/fields/{tag_template_field_id}
    * @param {string} request.newTagTemplateFieldId
-   *   Required. The new ID of this tag template field. For example,
-   *   `my_new_field`.
+   *   Required. The new ID of this tag template field. For example, `my_new_field`.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
@@ -2075,7 +2071,8 @@ export class DataCatalogClient {
    * Deletes a field in a tag template and all uses of that field.
    * Users should enable the Data Catalog API in the project identified by
    * the `name` parameter (see [Data Catalog Resource Project]
-   * (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for more information).
+   * (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+   * more information).
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -2187,8 +2184,8 @@ export class DataCatalogClient {
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.parent
-   *   Required. The name of the resource to attach this tag to. Tags can be
-   *   attached to Entries. Example:
+   *   Required. The name of the resource to attach this tag to. Tags can be attached to
+   *   Entries. Example:
    *
    *   * projects/{project_id}/locations/{location}/entryGroups/{entry_group_id}/entries/{entry_id}
    *
@@ -2461,9 +2458,8 @@ export class DataCatalogClient {
    *   - Tag templates.
    *   - Entries.
    *   - Entry groups.
-   * Note, this method cannot be used to manage policies for BigQuery, Cloud
-   * Pub/Sub and any external Google Cloud Platform resources synced to Cloud
-   * Data Catalog.
+   * Note, this method cannot be used to manage policies for BigQuery, Pub/Sub
+   * and any external Google Cloud Platform resources synced to Data Catalog.
    *
    * Callers must have following Google IAM permission
    *   - `datacatalog.tagTemplates.setIamPolicy` to set policies on tag
@@ -2557,9 +2553,8 @@ export class DataCatalogClient {
    *   - Tag templates.
    *   - Entries.
    *   - Entry groups.
-   * Note, this method cannot be used to manage policies for BigQuery, Cloud
-   * Pub/Sub and any external Google Cloud Platform resources synced to Cloud
-   * Data Catalog.
+   * Note, this method cannot be used to manage policies for BigQuery, Pub/Sub
+   * and any external Google Cloud Platform resources synced to Data Catalog.
    *
    * Callers must have following Google IAM permission
    *   - `datacatalog.tagTemplates.getIamPolicy` to get policies on tag
@@ -2653,9 +2648,8 @@ export class DataCatalogClient {
    *   - Tag templates.
    *   - Entries.
    *   - Entry groups.
-   * Note, this method cannot be used to manage policies for BigQuery, Cloud
-   * Pub/Sub and any external Google Cloud Platform resources synced to Cloud
-   * Data Catalog.
+   * Note, this method cannot be used to manage policies for BigQuery, Pub/Sub
+   * and any external Google Cloud Platform resources synced to Data Catalog.
    *
    * A caller is not required to have Google IAM permission to make this
    * request.
@@ -2757,15 +2751,18 @@ export class DataCatalogClient {
    * across repeated search queries.
    *
    * See [Data Catalog Search
-   * Syntax](https://cloud.google.com/data-catalog/docs/how-to/search-reference) for more information.
+   * Syntax](https://cloud.google.com/data-catalog/docs/how-to/search-reference)
+   * for more information.
    *
    * @param {Object} request
    *   The request object that will be sent.
    * @param {google.cloud.datacatalog.v1beta1.SearchCatalogRequest.Scope} request.scope
-   *   Required. The scope of this search request.
+   *   Required. The scope of this search request. A `scope` that has empty
+   *   `include_org_ids`, `include_project_ids` AND false
+   *   `include_gcp_public_datasets` is considered invalid. Data Catalog will
+   *   return an error in such a case.
    * @param {string} request.query
-   *   Required. The query string in search query syntax. The query must be
-   *   non-empty.
+   *   Required. The query string in search query syntax. The query must be non-empty.
    *
    *   Query strings can be simple as "x" or more qualified as:
    *
@@ -2775,14 +2772,15 @@ export class DataCatalogClient {
    *
    *   Note: Query tokens need to have a minimum of 3 characters for substring
    *   matching to work correctly. See [Data Catalog Search
-   *   Syntax](https://cloud.google.com/data-catalog/docs/how-to/search-reference) for more information.
+   *   Syntax](https://cloud.google.com/data-catalog/docs/how-to/search-reference)
+   *   for more information.
    * @param {number} request.pageSize
    *   Number of results in the search page. If <=0 then defaults to 10. Max limit
    *   for page_size is 1000. Throws an invalid argument for page_size > 1000.
    * @param {string} [request.pageToken]
    *   Optional. Pagination token returned in an earlier
-   *   {@link google.cloud.datacatalog.v1beta1.SearchCatalogResponse.next_page_token|SearchCatalogResponse.next_page_token},
-   *   which indicates that this is a continuation of a prior
+   *   {@link google.cloud.datacatalog.v1beta1.SearchCatalogResponse.next_page_token|SearchCatalogResponse.next_page_token}, which
+   *   indicates that this is a continuation of a prior
    *   {@link google.cloud.datacatalog.v1beta1.DataCatalog.SearchCatalog|SearchCatalogRequest}
    *   call, and that the system should return the next page of data. If empty,
    *   the first page is returned.
@@ -2867,10 +2865,12 @@ export class DataCatalogClient {
    * @param {Object} request
    *   The request object that will be sent.
    * @param {google.cloud.datacatalog.v1beta1.SearchCatalogRequest.Scope} request.scope
-   *   Required. The scope of this search request.
+   *   Required. The scope of this search request. A `scope` that has empty
+   *   `include_org_ids`, `include_project_ids` AND false
+   *   `include_gcp_public_datasets` is considered invalid. Data Catalog will
+   *   return an error in such a case.
    * @param {string} request.query
-   *   Required. The query string in search query syntax. The query must be
-   *   non-empty.
+   *   Required. The query string in search query syntax. The query must be non-empty.
    *
    *   Query strings can be simple as "x" or more qualified as:
    *
@@ -2880,14 +2880,15 @@ export class DataCatalogClient {
    *
    *   Note: Query tokens need to have a minimum of 3 characters for substring
    *   matching to work correctly. See [Data Catalog Search
-   *   Syntax](https://cloud.google.com/data-catalog/docs/how-to/search-reference) for more information.
+   *   Syntax](https://cloud.google.com/data-catalog/docs/how-to/search-reference)
+   *   for more information.
    * @param {number} request.pageSize
    *   Number of results in the search page. If <=0 then defaults to 10. Max limit
    *   for page_size is 1000. Throws an invalid argument for page_size > 1000.
    * @param {string} [request.pageToken]
    *   Optional. Pagination token returned in an earlier
-   *   {@link google.cloud.datacatalog.v1beta1.SearchCatalogResponse.next_page_token|SearchCatalogResponse.next_page_token},
-   *   which indicates that this is a continuation of a prior
+   *   {@link google.cloud.datacatalog.v1beta1.SearchCatalogResponse.next_page_token|SearchCatalogResponse.next_page_token}, which
+   *   indicates that this is a continuation of a prior
    *   {@link google.cloud.datacatalog.v1beta1.DataCatalog.SearchCatalog|SearchCatalogRequest}
    *   call, and that the system should return the next page of data. If empty,
    *   the first page is returned.
@@ -2928,10 +2929,12 @@ export class DataCatalogClient {
    * @param {Object} request
    *   The request object that will be sent.
    * @param {google.cloud.datacatalog.v1beta1.SearchCatalogRequest.Scope} request.scope
-   *   Required. The scope of this search request.
+   *   Required. The scope of this search request. A `scope` that has empty
+   *   `include_org_ids`, `include_project_ids` AND false
+   *   `include_gcp_public_datasets` is considered invalid. Data Catalog will
+   *   return an error in such a case.
    * @param {string} request.query
-   *   Required. The query string in search query syntax. The query must be
-   *   non-empty.
+   *   Required. The query string in search query syntax. The query must be non-empty.
    *
    *   Query strings can be simple as "x" or more qualified as:
    *
@@ -2941,14 +2944,15 @@ export class DataCatalogClient {
    *
    *   Note: Query tokens need to have a minimum of 3 characters for substring
    *   matching to work correctly. See [Data Catalog Search
-   *   Syntax](https://cloud.google.com/data-catalog/docs/how-to/search-reference) for more information.
+   *   Syntax](https://cloud.google.com/data-catalog/docs/how-to/search-reference)
+   *   for more information.
    * @param {number} request.pageSize
    *   Number of results in the search page. If <=0 then defaults to 10. Max limit
    *   for page_size is 1000. Throws an invalid argument for page_size > 1000.
    * @param {string} [request.pageToken]
    *   Optional. Pagination token returned in an earlier
-   *   {@link google.cloud.datacatalog.v1beta1.SearchCatalogResponse.next_page_token|SearchCatalogResponse.next_page_token},
-   *   which indicates that this is a continuation of a prior
+   *   {@link google.cloud.datacatalog.v1beta1.SearchCatalogResponse.next_page_token|SearchCatalogResponse.next_page_token}, which
+   *   indicates that this is a continuation of a prior
    *   {@link google.cloud.datacatalog.v1beta1.DataCatalog.SearchCatalog|SearchCatalogRequest}
    *   call, and that the system should return the next page of data. If empty,
    *   the first page is returned.
@@ -3022,16 +3026,16 @@ export class DataCatalogClient {
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.parent
-   *   Required. The name of the location that contains the entry groups, which
-   *   can be provided in URL format. Example:
+   *   Required. The name of the location that contains the entry groups, which can be
+   *   provided in URL format. Example:
    *
    *   * projects/{project_id}/locations/{location}
    * @param {number} [request.pageSize]
-   *   Optional. The maximum number of items to return. Default is 10. Max limit
-   *   is 1000. Throws an invalid argument for `page_size > 1000`.
+   *   Optional. The maximum number of items to return. Default is 10. Max limit is 1000.
+   *   Throws an invalid argument for `page_size > 1000`.
    * @param {string} [request.pageToken]
-   *   Optional. Token that specifies which page is requested. If empty, the first
-   *   page is returned.
+   *   Optional. Token that specifies which page is requested. If empty, the first page is
+   *   returned.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
@@ -3111,16 +3115,16 @@ export class DataCatalogClient {
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.parent
-   *   Required. The name of the location that contains the entry groups, which
-   *   can be provided in URL format. Example:
+   *   Required. The name of the location that contains the entry groups, which can be
+   *   provided in URL format. Example:
    *
    *   * projects/{project_id}/locations/{location}
    * @param {number} [request.pageSize]
-   *   Optional. The maximum number of items to return. Default is 10. Max limit
-   *   is 1000. Throws an invalid argument for `page_size > 1000`.
+   *   Optional. The maximum number of items to return. Default is 10. Max limit is 1000.
+   *   Throws an invalid argument for `page_size > 1000`.
    * @param {string} [request.pageToken]
-   *   Optional. Token that specifies which page is requested. If empty, the first
-   *   page is returned.
+   *   Optional. Token that specifies which page is requested. If empty, the first page is
+   *   returned.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Stream}
@@ -3156,16 +3160,16 @@ export class DataCatalogClient {
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.parent
-   *   Required. The name of the location that contains the entry groups, which
-   *   can be provided in URL format. Example:
+   *   Required. The name of the location that contains the entry groups, which can be
+   *   provided in URL format. Example:
    *
    *   * projects/{project_id}/locations/{location}
    * @param {number} [request.pageSize]
-   *   Optional. The maximum number of items to return. Default is 10. Max limit
-   *   is 1000. Throws an invalid argument for `page_size > 1000`.
+   *   Optional. The maximum number of items to return. Default is 10. Max limit is 1000.
+   *   Throws an invalid argument for `page_size > 1000`.
    * @param {string} [request.pageToken]
-   *   Optional. Token that specifies which page is requested. If empty, the first
-   *   page is returned.
+   *   Optional. Token that specifies which page is requested. If empty, the first page is
+   *   returned.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Object}
@@ -3453,8 +3457,8 @@ export class DataCatalogClient {
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.parent
-   *   Required. The name of the Data Catalog resource to list the tags of. The
-   *   resource could be an {@link google.cloud.datacatalog.v1beta1.Entry|Entry} or an
+   *   Required. The name of the Data Catalog resource to list the tags of. The resource
+   *   could be an {@link google.cloud.datacatalog.v1beta1.Entry|Entry} or an
    *   {@link google.cloud.datacatalog.v1beta1.EntryGroup|EntryGroup}.
    *
    *   Examples:
@@ -3545,8 +3549,8 @@ export class DataCatalogClient {
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.parent
-   *   Required. The name of the Data Catalog resource to list the tags of. The
-   *   resource could be an {@link google.cloud.datacatalog.v1beta1.Entry|Entry} or an
+   *   Required. The name of the Data Catalog resource to list the tags of. The resource
+   *   could be an {@link google.cloud.datacatalog.v1beta1.Entry|Entry} or an
    *   {@link google.cloud.datacatalog.v1beta1.EntryGroup|EntryGroup}.
    *
    *   Examples:
@@ -3593,8 +3597,8 @@ export class DataCatalogClient {
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.parent
-   *   Required. The name of the Data Catalog resource to list the tags of. The
-   *   resource could be an {@link google.cloud.datacatalog.v1beta1.Entry|Entry} or an
+   *   Required. The name of the Data Catalog resource to list the tags of. The resource
+   *   could be an {@link google.cloud.datacatalog.v1beta1.Entry|Entry} or an
    *   {@link google.cloud.datacatalog.v1beta1.EntryGroup|EntryGroup}.
    *
    *   Examples:

--- a/src/v1beta1/data_catalog_client_config.json
+++ b/src/v1beta1/data_catalog_client_config.json
@@ -31,6 +31,7 @@
           "retry_params_name": "default"
         },
         "UpdateEntryGroup": {
+          "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
@@ -45,6 +46,7 @@
           "retry_params_name": "default"
         },
         "ListEntryGroups": {
+          "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
@@ -74,6 +76,7 @@
           "retry_params_name": "default"
         },
         "ListEntries": {
+          "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },

--- a/synth.metadata
+++ b/synth.metadata
@@ -4,15 +4,22 @@
       "git": {
         "name": ".",
         "remote": "git@github.com:googleapis/nodejs-datacatalog.git",
-        "sha": "ab68b2af996f3676441db229110ce26b6eb80dff"
+        "sha": "654f4d18e4454c905e34591d8838977dbf94e287"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "629e6bea8418ad4a5d081ab9eb48bb327ad368e1",
-        "internalRef": "306660765"
+        "sha": "42ee97c1b93a0e3759bbba3013da309f670a90ab",
+        "internalRef": "307114445"
+      }
+    },
+    {
+      "git": {
+        "name": "synthtool",
+        "remote": "https://github.com/googleapis/synthtool.git",
+        "sha": "19465d3ec5e5acdb01521d8f3bddd311bcbee28d"
       }
     }
   ],

--- a/synth.py
+++ b/synth.py
@@ -47,12 +47,6 @@ common_templates = gcp.CommonTemplates()
 templates = common_templates.node_library(source_location='build/src')
 s.copy(templates, excludes=[])
 
-# Fix broken links to cloud.google.com documentation
-s.replace('src/v1beta1/*.ts', '/data-catalog/docs/', 'https://cloud.google.com/data-catalog/docs/')
-s.replace('src/v1beta1/*.ts',
-        '/compute/docs/regions-zones/',
-        'https://cloud.google.com/compute/docs/regions-zones/')
-
 # Node.js specific cleanup
 subprocess.run(['npm', 'install'])
 subprocess.run(['npm', 'run', 'fix'])


### PR DESCRIPTION
1. feat: add `order` field to `TagField` and `TagTemplateField` message in tags.proto
2. fix: broken document links & polish comments
3. chore: update copyright for proto files
4. feat: add csharp/ruby/PHP namespaces